### PR TITLE
Fix installing and running as a gh CLI extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@
 At its simplest, you give it a JSON config file and a repository name:
 
 ```
-gh-provision-envs config.json myuser/myrepo
+npx gh-provision-envs -c config.json -R myuser/myrepo
 ```
 
 If you have the `gh-provision-envs` tool on your path, you can also run it as an extension to the `gh` CLI tool:
 
 ```
-gh provision-envs config.json myuser/myrepo
+gh extension install AyogoHealth/gh-provision-envs
+gh provision-envs -c config.json -R myuser/myrepo
 ```
 
 ### Disclaimers

--- a/gh-provision-envs
+++ b/gh-provision-envs
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+# Determine if an executable is in the PATH
+if ! type -p node >/dev/null; then
+   echo "Node not found on the system" >&2
+   exit 1
+fi
+
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+# Pass arguments through to another command
+node ${SCRIPT_DIR}/gh-provision-envs-cli.js "$@"

--- a/gh-provision-envs-cli.js
+++ b/gh-provision-envs-cli.js
@@ -6,18 +6,29 @@ import { readFileSync } from "node:fs";
 import { provisionEnvironments } from "./index.js";
 
 
-const args = parseArgs({ allowPositionals: true, options: {}});
-if (args.positionals.length < 1) {
-  console.error(`Must provide a configuration file path`);
+const args = parseArgs({ options: {
+  "repo": {
+    type: "string",
+    short: "R"
+  },
+  "config": {
+    type: "string",
+    short: "c"
+  }
+}});
+
+if (!("config" in args.values)) {
+  console.error(`Must provide a configuration file path with --config`);
   process.exit(1);
 }
-if (args.positionals.length < 2) {
+
+if (!("repo" in args.values)) {
   console.error(`Must provide a repository name (in "owner/repo" format)`);
   process.exit(1);
 }
 
-const configFile = args.positionals[0];
-const repoName = args.positionals[1];
+const configFile = args.values.config;
+const repoName = args.values.repo;
 let configData = {};
 
 try {


### PR DESCRIPTION
This moves to using `-c` (or `--config`) to provide the config file name, and `-R` (or `--repo`) to provide the repository name, to match conventions of the `gh` CLI tool.

You should be able to install this with `gh extension install AyogoHealth/gh-provision-envs` and then run it through `gh` after this is merged